### PR TITLE
adding API pagination support, examples, tests

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,140 @@
+# MN Lite Operations 
+
+MN Lite collects schema.org content from a source, and registers it in a local sqlite database, do be served via the DataONE API.
+
+Harvesting is implemented as a scrapy crawler[^scrapy]. Given a sitemap, crawls and adds discovered `SO:Dataset` entries to the persistence store.
+
+[^scrapy]: https://docs.scrapy.org/en/latest/index.html
+
+## DataONE production and testing hosts
+
+- Test server: so.test.dataone.org
+    - Environment: `~mnlite`
+    - Virtual env: `mnlite`
+- Production server: sonode.dataone.org
+    - Environment: `~mnlite`
+    - Virtual env: `mnlite`
+
+## Testing
+
+- Prerequisite: Content follows SOSO guidelines
+    - Validation: https://shacl-playground.zazuko.com/
+    - [SOSO SHACL file](https://github.com/ESIPFed/science-on-schema.org/blob/develop/validation/shapegraphs/soso_common_v1.2.3.ttl)
+
+## Production Deployment
+
+1. Log in to sonode.dataone.org (or so.test.dataone.org for testing)
+2. `sudo su - mnlite`
+3. `workon mnlite` (`conda activate mnlite` on the test node)
+4. `cd WORK/mnlite`
+5. Initialize a new repository: `opersist -f instance/nodes/HAKAI_IYS init`
+6. Create a contact subject: `opersist -f instance/nodes/HAKAI_IYS sub -o create -n "Brett Johnson" -s "http://orcid.org/0000-0001-9317-0364"`
+7. Create a node subject: `opersist -f instance/nodes/HAKAI_IYS sub -o create -n "HAKAI_IYS" -s "urn:node:HAKAI_IYS"`
+8. Edit the node.json document to set the contact and node id and other metadata details like description
+    - `vim instance/nodes/mnTestHAKAI_IYS/node.json`
+```json
+{
+  "node": {
+    "node_id": "urn:node:HAKAI_IYS",
+    "state": "up",
+    "name": "International Year of the Salmon Catalogue",
+    "description": "The repository contains data collected and rescued by the International Year of the Salmon project facilitated by the North Pacific Anadromous Fish Commission. The repository primarily contains physical and biogeochemical oceanographic data and fisheries trawl catch data describing salmon abundance and environmental conditions in the North Pacific Ocean collected from research expeditions in 2019, 2020, and 2022.",
+    "base_url": "https://sonode.dataone.org/HAKAI_IYS/",
+    "schedule": {
+      "hour": "*",
+      "day": "*",
+      "min": "1,11,21,31,41,51",
+      "mon": "*",
+      "sec": "5",
+      "wday": "?",
+      "year": "*"
+    },
+    "subject": "urn:node:HAKAI_IYS",
+    "contact_subject": "http://orcid.org/0000-0001-9317-0364"
+  },
+  "content_database": "sqlite:///content.db",
+  "log_database": "sqlite:///eventlog.db",
+  "data_folder": "data",
+  "created": "2022-08-05T17:50:36+0000",
+  "default_submitter": "http://orcid.org/0000-0001-9317-0364",
+  "default_owner": "http://orcid.org/0000-0001-9317-0364",
+  "spider": {
+    "sitemap_urls":[
+      "https://iys.hakai.org/sitemap/sitemap.xml"
+    ]
+  }
+}
+
+```
+9. `sudo systemctl restart mnlite`
+    - Node document is available from https://sonode.dataone.org/HAKAI_IYS/v2/node
+11. Run first harvest
+    - `scrapy crawl JsonldSpider  -s STORE_PATH=instance/nodes/HAKAI_IYS > /var/log/mnlite/HAKAI_IYS-crawl-01.log 2>&1`
+12. Set up a cron job for harvest
+- To use the venv, need to be sure to use bash and not sh
+- `crontab -e`
+```
+SHELL=/bin/bash
+20 * * * * cd ~/WORK/mnlite && workon mnlite && scrapy crawl JsonldSpider -s STORE_PATH=instance/nodes/HAKAI_IYS >> /var/log/mnlite/HAKAI_IYS-crawl-01.log 2>&1
+```
+
+## Register node in production and approve node
+
+14. SSH to cn-ucsb-1.dataone.org (or cn-stage-ucsb-1.test.dataone.org for testing)
+
+Execute the following commands on the CN.
+
+### Add the user to the accounts service
+
+15. Create an XML doc for the subject of this format:
+```xml
+$ cat hakai-bjohnson.xml
+<?xml version="1.0" encoding="UTF-8"?>
+<ns2:person xmlns:ns2="http://ns.dataone.org/service/types/v1">
+  <subject>http://orcid.org/0000-0001-9317-0364</subject>
+  <givenName>Brett</givenName>
+  <familyName>Johnson</familyName>
+  <verified>false</verified>
+</ns2:person>
+```
+
+16. Create and validate the subject in the accounts service
+- `$ curl -s --cert /etc/dataone/client/private/urn_node_cnStageUCSB1.pem -F person=@hakai-bjohnson.xml -X POST "https://cn-stage.test.dataone.org/cn/v2/accounts"`
+- `$ curl -s --cert /etc/dataone/client/private/urn_node_cnStageUCSB1.pem -X PUT  "https://cn-stage.test.dataone.org/cn/v2/accounts/verification/http%3A%2F%2Forcid.org%2F0000-0001-9317-0364"`
+
+18. Download the node capabilities doc and register the node, and then approve the node in DataONE
+- `$ curl "https://sonode.dataone.org/HAKAI_IYS/v2/node" > hakai-node.xml`
+- `$ sudo curl --cert /etc/dataone/client/private/urn_node_cnStageUCSB1.pem -X POST -F 'node=@hakai-node.xml' "https://cn-stage-ucsb-1.test.dataone.org/cn/v2/node"`
+
+```
+$ sudo /usr/local/bin/dataone-approve-node
+Choose the number of the Certificate to use
+0)	urn_node_cnStageUCSB1.pem
+1)	urn:node:cnStageUCSB1.pem
+0
+[ WARN] 2022-05-05 03:27:54,071 (CertificateManager:<init>:203) FileNotFound: No certificate installed in the default location: /tmp/x509up_u0
+May 05, 2022 3:27:54 AM com.hazelcast.client.LifecycleServiceClientImpl
+INFO: HazelcastClient is STARTING
+May 05, 2022 3:27:54 AM com.hazelcast.client.LifecycleServiceClientImpl
+INFO: HazelcastClient is CLIENT_CONNECTION_OPENING
+May 05, 2022 3:27:54 AM com.hazelcast.client.LifecycleServiceClientImpl
+INFO: HazelcastClient is CLIENT_CONNECTION_OPENED
+May 05, 2022 3:27:54 AM com.hazelcast.client.LifecycleServiceClientImpl
+INFO: HazelcastClient is STARTED
+Pending Nodes to Approve
+0) urn:node:mnStageORC1	1) urn:node:mnStageLTER	2) urn:node:mnStageCDL	3) urn:node:USGSCSAS
+4) urn:node:ORNLDAAC	5) urn:node:mnTestTFRI	6) urn:node:mnTestUSANPN	7) urn:node:TestKUBI
+8) urn:node:EDACGSTORE	9) urn:node:mnTestDRYAD	10) urn:node:DRYAD	11) urn:node:mnTestGLEON
+12) urn:node:mnDemo11	13) urn:node:mnTestEDORA	14) urn:node:mnTestRGD	15) urn:node:mnTestIOE
+16) urn:node:mnTestNRDC	17) urn:node:mnTestNRDC1	18) urn:node:mnTestPPBIO	19) urn:node:mnTestUIC
+20) urn:node:mnTestFEMC	21) urn:node:mnTestHAKAI_IYS
+Type the number of the Node to verify and press enter (return):
+21
+Do you wish to approve urn:node:mnTestHAKAI_IYS (Y=yes,N=no,C=cancel)
+Y
+Node Approved in LDAP
+Hazelcast Node Topic published to. Approval Complete
+```
+
+:tada: :tada: :tada:
+

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,6 +1,6 @@
 # MN Lite Operations 
 
-MN Lite collects schema.org content from a source, and registers it in a local sqlite database, do be served via the DataONE API.
+MN Lite collects schema.org content from a source, and registers it in a local sqlite database, to be served via the DataONE API.
 
 Harvesting is implemented as a scrapy crawler[^scrapy]. Given a sitemap, crawls and adds discovered `SO:Dataset` entries to the persistence store.
 

--- a/docs/operation.md
+++ b/docs/operation.md
@@ -57,10 +57,10 @@ source "${ENV_DIR}/bin/activate"
 LOG_FILE="${LOG_DIR}/${NODE}-crawl.log"
 mkdir -p ${LOG_DIR}
 touch ${LOG_FILE}
-echo "${date} Start crawl on: ${NODE} logfile: ${LOG_FILE}" >> ${LOG_FILE}
+echo "${date -Is} Start crawl on: ${NODE} logfile: ${LOG_FILE}" >> ${LOG_FILE}
 SPIDER_CLASS=$(jq -r '.SPIDER_CLASS // "JsonldSpider"' "${NODE_DIR}/settings.json")
 scrapy crawl --logfile=${LOG_FILE} "${SPIDER_CLASS}" -s STORE_PATH=${NODE_DIR}
-echo "${date} End crawl on ${NODE}" >> ${LOG_FILE}
+echo "${date -Is} End crawl on ${NODE}" >> ${LOG_FILE}
 ```
 
 Settings file (`NODE_DIR/settings.json`):

--- a/docs/operation.md
+++ b/docs/operation.md
@@ -1,140 +1,158 @@
-# MN Lite Operations 
+# Operation
 
-MN Lite collects schema.org content from a source, and registers it in a local sqlite database, do be served via the DataONE API.
+## Sitemap crawl configuration sample
 
-Harvesting is implemented as a scrapy crawler[^scrapy]. Given a sitemap, crawls and adds discovered `SO:Dataset` entries to the persistence store.
+Node configuration (`NODE_DIR/node.json`):
 
-[^scrapy]: https://docs.scrapy.org/en/latest/index.html
-
-## DataONE production and testing hosts
-
-- Test server: so.test.dataone.org
-    - Environment: `~mnlite`
-    - Virtual env: `mnlite`
-- Production server: sonode.dataone.org
-    - Environment: `~mnlite`
-    - Virtual env: `mnlite`
-
-## Testing
-
-- Prerequisite: Content follows SOSO guidelines
-    - Validation: https://shacl-playground.zazuko.com/
-    - [SOSO SHACL file](https://github.com/ESIPFed/science-on-schema.org/blob/develop/validation/shapegraphs/soso_common_v1.2.3.ttl)
-
-## Production Deployment
-
-1. Log in to sonode.dataone.org (or so.test.dataone.org for testing)
-2. `sudo su - mnlite`
-3. `workon mnlite` (`conda activate mnlite` on the test node)
-4. `cd WORK/mnlite`
-5. Initialize a new repository: `opersist -f instance/nodes/HAKAI_IYS init`
-6. Create a contact subject: `opersist -f instance/nodes/HAKAI_IYS sub -o create -n "Brett Johnson" -s "http://orcid.org/0000-0001-9317-0364"`
-7. Create a node subject: `opersist -f instance/nodes/HAKAI_IYS sub -o create -n "HAKAI_IYS" -s "urn:node:HAKAI_IYS"`
-8. Edit the node.json document to set the contact and node id and other metadata details like description
-    - `vim instance/nodes/mnTestHAKAI_IYS/node.json`
 ```json
 {
-  "node": {
-    "node_id": "urn:node:HAKAI_IYS",
-    "state": "up",
-    "name": "International Year of the Salmon Catalogue",
-    "description": "The repository contains data collected and rescued by the International Year of the Salmon project facilitated by the North Pacific Anadromous Fish Commission. The repository primarily contains physical and biogeochemical oceanographic data and fisheries trawl catch data describing salmon abundance and environmental conditions in the North Pacific Ocean collected from research expeditions in 2019, 2020, and 2022.",
-    "base_url": "https://sonode.dataone.org/HAKAI_IYS/",
-    "schedule": {
-      "hour": "*",
-      "day": "*",
-      "min": "1,11,21,31,41,51",
-      "mon": "*",
-      "sec": "5",
-      "wday": "?",
-      "year": "*"
+    "node": {
+        "node_id": "urn:node:mnTestHD",
+        "state": "up",
+        "name": "Harvard Dataverse",
+        "description": "The Harvard Dataverse Repository is a free data repository open to all researchers from any discipline, both inside and outside of the Harvard community, where you can share, archive, cite, access, and explore research data. Each individual Dataverse collection is a customizable collection of datasets (or a virtual repository) for organizing, managing, and showcasing datasets.",
+        "base_url": "https://so.test.dataone.org/mnTestHD",
+        "schedule": {
+            "hour": "*",
+            "day": "*",
+            "min": "*/3",
+            "mon": "*",
+            "sec": "0",
+            "wday": "?",
+            "year": "*"
+        },
+        "subject": "CN=urn:node:mnTestHD,DC=dataone,DC=org",
+        "contact_subject": "http://orcid.org/0000-0001-5828-6070"
     },
-    "subject": "urn:node:HAKAI_IYS",
-    "contact_subject": "http://orcid.org/0000-0001-9317-0364"
-  },
-  "content_database": "sqlite:///content.db",
-  "log_database": "sqlite:///eventlog.db",
-  "data_folder": "data",
-  "created": "2022-08-05T17:50:36+0000",
-  "default_submitter": "http://orcid.org/0000-0001-9317-0364",
-  "default_owner": "http://orcid.org/0000-0001-9317-0364",
+    "content_database": "sqlite:///content.db",
+    "log_database": "sqlite:///eventlog.db",
+    "data_folder": "data",
+    "created": "2023-08-14T14:35:09+0000",
+    "default_submitter": "http://orcid.org/0000-0001-5828-6070",
+    "default_owner": "http://orcid.org/0000-0001-5828-6070",
+    "spider": {
+        "sitemap_urls": [
+            "https://raw.githubusercontent.com/DataONEorg/mnlite/develop/tests/testHDsitemap.xml"
+        ]
+    }
+}
+```
+
+Sync script (`NODE_DIR/sync_content.sh`):
+
+```bash
+#!/bin/bash
+
+NODE="mnTestHD"
+
+HOME_DIR="/home/mnlite"
+MNLITE_DIR="${HOME_DIR}/WORK/mnlite"
+NODE_DIR="${MNLITE_DIR}/instance/nodes/${NODE}"
+
+ENV_DIR="${HOME_DIR}/.virtualenvs/mnlite"
+LOG_DIR="/var/log/mnlite"
+
+cd "${MNLITE_DIR}"
+source "${ENV_DIR}/bin/activate"
+LOG_FILE="${LOG_DIR}/${NODE}-crawl.log"
+mkdir -p ${LOG_DIR}
+touch ${LOG_FILE}
+echo "${date} Start crawl on: ${NODE} logfile: ${LOG_FILE}" >> ${LOG_FILE}
+scrapy crawl --logfile=${LOG_FILE} JsonldSpider -s STORE_PATH=${NODE_DIR}
+echo "${date} End crawl on ${NODE}" >> ${LOG_FILE}
+```
+
+Settings file (`NODE_DIR/settings.json`):
+
+```json
+{
+    "AUTOTHROTTLE_TARGET_CONCURRENCY": 1,
+    "DOWNLOAD_DELAY": 1,
+    "LOG_LEVEL": "DEBUG"
+}
+```
+
+
+## API crawl configuration sample
+
+Use `node.json` for source URL(s) in `spider.sitemap_urls`, even when the source is an API endpoint.
+
+Example `node.json` snippet (see above for full example):
+
+```json
+{
+  ...
   "spider": {
-    "sitemap_urls":[
-      "https://iys.hakai.org/sitemap/sitemap.xml"
+    "sitemap_urls": [
+      "https://example.org/api/datasets"
     ]
   }
 }
-
-```
-9. `sudo systemctl restart mnlite`
-    - Node document is available from https://sonode.dataone.org/HAKAI_IYS/v2/node
-11. Run first harvest
-    - `scrapy crawl JsonldSpider  -s STORE_PATH=instance/nodes/HAKAI_IYS > /var/log/mnlite/HAKAI_IYS-crawl-01.log 2>&1`
-12. Set up a cron job for harvest
-- To use the venv, need to be sure to use bash and not sh
-- `crontab -e`
-```
-SHELL=/bin/bash
-20 * * * * cd ~/WORK/mnlite && workon mnlite && scrapy crawl JsonldSpider -s STORE_PATH=instance/nodes/HAKAI_IYS >> /var/log/mnlite/HAKAI_IYS-crawl-01.log 2>&1
 ```
 
-## Register node in production and approve node
+Select the spider class in `settings.json`.
 
-14. SSH to cn-ucsb-1.dataone.org (or cn-stage-ucsb-1.test.dataone.org for testing)
+### API with explicit "next" URL in response body
 
-Execute the following commands on the CN.
-
-### Add the user to the accounts service
-
-15. Create an XML doc for the subject of this format:
-```xml
-$ cat hakai-bjohnson.xml
-<?xml version="1.0" encoding="UTF-8"?>
-<ns2:person xmlns:ns2="http://ns.dataone.org/service/types/v1">
-  <subject>http://orcid.org/0000-0001-9317-0364</subject>
-  <givenName>Brett</givenName>
-  <familyName>Johnson</familyName>
-  <verified>false</verified>
-</ns2:person>
+```json
+{
+  "SPIDER_CLASS": "APIJsonldSpider",
+  "api_records_path": "items",
+  "api_next_path": "next",
+  "api_jsonld_field": "jsonld",
+  "api_url_field": "url",
+  "api_modified_field": "modified"
+}
 ```
 
-16. Create and validate the subject in the accounts service
-- `$ curl -s --cert /etc/dataone/client/private/urn_node_cnStageUCSB1.pem -F person=@hakai-bjohnson.xml -X POST "https://cn-stage.test.dataone.org/cn/v2/accounts"`
-- `$ curl -s --cert /etc/dataone/client/private/urn_node_cnStageUCSB1.pem -X PUT  "https://cn-stage.test.dataone.org/cn/v2/accounts/verification/http%3A%2F%2Forcid.org%2F0000-0001-9317-0364"`
+### API with fixed page size and incremental `page` parameter
 
-18. Download the node capabilities doc and register the node, and then approve the node in DataONE
-- `$ curl "https://sonode.dataone.org/HAKAI_IYS/v2/node" > hakai-node.xml`
-- `$ sudo curl --cert /etc/dataone/client/private/urn_node_cnStageUCSB1.pem -X POST -F 'node=@hakai-node.xml' "https://cn-stage-ucsb-1.test.dataone.org/cn/v2/node"`
-
-```
-$ sudo /usr/local/bin/dataone-approve-node
-Choose the number of the Certificate to use
-0)	urn_node_cnStageUCSB1.pem
-1)	urn:node:cnStageUCSB1.pem
-0
-[ WARN] 2022-05-05 03:27:54,071 (CertificateManager:<init>:203) FileNotFound: No certificate installed in the default location: /tmp/x509up_u0
-May 05, 2022 3:27:54 AM com.hazelcast.client.LifecycleServiceClientImpl
-INFO: HazelcastClient is STARTING
-May 05, 2022 3:27:54 AM com.hazelcast.client.LifecycleServiceClientImpl
-INFO: HazelcastClient is CLIENT_CONNECTION_OPENING
-May 05, 2022 3:27:54 AM com.hazelcast.client.LifecycleServiceClientImpl
-INFO: HazelcastClient is CLIENT_CONNECTION_OPENED
-May 05, 2022 3:27:54 AM com.hazelcast.client.LifecycleServiceClientImpl
-INFO: HazelcastClient is STARTED
-Pending Nodes to Approve
-0) urn:node:mnStageORC1	1) urn:node:mnStageLTER	2) urn:node:mnStageCDL	3) urn:node:USGSCSAS
-4) urn:node:ORNLDAAC	5) urn:node:mnTestTFRI	6) urn:node:mnTestUSANPN	7) urn:node:TestKUBI
-8) urn:node:EDACGSTORE	9) urn:node:mnTestDRYAD	10) urn:node:DRYAD	11) urn:node:mnTestGLEON
-12) urn:node:mnDemo11	13) urn:node:mnTestEDORA	14) urn:node:mnTestRGD	15) urn:node:mnTestIOE
-16) urn:node:mnTestNRDC	17) urn:node:mnTestNRDC1	18) urn:node:mnTestPPBIO	19) urn:node:mnTestUIC
-20) urn:node:mnTestFEMC	21) urn:node:mnTestHAKAI_IYS
-Type the number of the Node to verify and press enter (return):
-21
-Do you wish to approve urn:node:mnTestHAKAI_IYS (Y=yes,N=no,C=cancel)
-Y
-Node Approved in LDAP
-Hazelcast Node Topic published to. Approval Complete
+```json
+{
+  "SPIDER_CLASS": "APIJsonldSpider",
+  "api_records_path": "items",
+  "api_jsonld_field": "jsonld",
+  "api_url_field": "url",
+  "api_modified_field": "modified",
+  "api_page_param": "page",
+  "api_start_page": 1,
+  "api_stop_status_codes": [404]
+}
 ```
 
-:tada: :tada: :tada:
+In page-parameter mode, mnlite requests page 1, 2, 3, ... and stops either when it receives a stop status (e.g. 404) or when a successful page returns no records.
+The query URLs are built as: `https://example.org/api/datasets?page=1`, `?page=2`, etc.
 
+### Working example: Polar Data Catalogue
+
+The PDC API at `https://polardata.ca/api/metadata?page=0` returns a schema.org
+`ItemList` where each element is a `ListItem` wrapping a `Dataset`. The `@context`
+is placed once on the envelope, not on individual records — the spider automatically
+propagates it down to each extracted `Dataset`.
+
+`node.json` — spider section:
+
+```json
+"spider": {
+  "sitemap_urls": [
+    "https://polardata.ca/api/metadata"
+  ]
+}
+```
+
+`settings.json`:
+
+```json
+{
+  "SPIDER_CLASS": "APIJsonldSpider",
+  "api_records_path": "itemListElement",
+  "api_jsonld_field": "item",
+  "api_url_field": "item.url",
+  "api_modified_field": "item.dateModified",
+  "api_page_param": "page",
+  "api_start_page": 0,
+  "api_stop_status_codes": [404, 204]
+}
+```
+
+The spider requests `?page=0`, `?page=1`, ... until an empty page or a 404 is received.

--- a/docs/operation.md
+++ b/docs/operation.md
@@ -58,7 +58,8 @@ LOG_FILE="${LOG_DIR}/${NODE}-crawl.log"
 mkdir -p ${LOG_DIR}
 touch ${LOG_FILE}
 echo "${date} Start crawl on: ${NODE} logfile: ${LOG_FILE}" >> ${LOG_FILE}
-scrapy crawl --logfile=${LOG_FILE} JsonldSpider -s STORE_PATH=${NODE_DIR}
+SPIDER_CLASS=$(jq -r '.SPIDER_CLASS // "JsonldSpider"' "${NODE_DIR}/settings.json")
+scrapy crawl --logfile=${LOG_FILE} "${SPIDER_CLASS}" -s STORE_PATH=${NODE_DIR}
 echo "${date} End crawl on ${NODE}" >> ${LOG_FILE}
 ```
 
@@ -66,6 +67,7 @@ Settings file (`NODE_DIR/settings.json`):
 
 ```json
 {
+    "SPIDER_CLASS": "JsonldSpider",
     "AUTOTHROTTLE_TARGET_CONCURRENCY": 1,
     "DOWNLOAD_DELAY": 1,
     "LOG_LEVEL": "DEBUG"

--- a/mnonboard/defs.py
+++ b/mnonboard/defs.py
@@ -81,8 +81,24 @@ LOG_DIR="/var/log/mnlite"
 cd "${MNLITE_DIR}"
 source "${ENV_DIR}/bin/activate"
 LOG_FILE="${LOG_DIR}/${NODE}-crawl.log"
+SPIDER_CLASS="$(${ENV_DIR}/bin/python - <<PY
+import json
+from pathlib import Path
+
+settings_path = Path("${NODE_DIR}") / "settings.json"
+spider_name = "JsonldSpider"
+try:
+    if settings_path.exists():
+        with open(settings_path) as src:
+            cfg = json.load(src)
+        spider_name = cfg.get("SPIDER_CLASS", "JsonldSpider")
+except Exception:
+    pass
+print(spider_name)
+PY
+)"
 logger "Start crawl on: ${NODE} logfile: ${LOG_FILE}"
-scrapy crawl --logfile=${LOG_FILE} JsonldSpider -s STORE_PATH=${NODE_DIR}
+scrapy crawl --logfile=${LOG_FILE} ${SPIDER_CLASS} -s STORE_PATH=${NODE_DIR}
 logger "End crawl on ${NODE}"
 """
 
@@ -153,7 +169,8 @@ SITEMAP_URLS = []
 
 DEFAULT_SETTINGS = {
     "AUTOTHROTTLE_TARGET_CONCURRENCY": 1.5,
-    "LOG_LEVEL": "DEBUG"
+    "LOG_LEVEL": "DEBUG",
+    "SPIDER_CLASS": "JsonldSpider",
 }
 
 SCHEDULES = {

--- a/soscan/spiders/apijsonldspider.py
+++ b/soscan/spiders/apijsonldspider.py
@@ -1,0 +1,314 @@
+import json
+import logging
+from pathlib import Path
+from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
+
+from scrapy.http import Request
+from scrapy.spiders import Spider
+
+import soscan.items
+import soscan.utils
+
+
+logger = logging.getLogger(__name__)
+
+
+def extract_path(data, path, default=None):
+    """
+    Resolve a dotted path against a dict/list structure.
+
+    Examples:
+        items
+        payload.results
+        feed.0
+        feed.0.jsonld
+    """
+    if path in (None, "", "."):
+        return data
+    current = data
+    for part in path.split("."):
+        if isinstance(current, list):
+            try:
+                current = current[int(part)]
+            except (TypeError, ValueError, IndexError):
+                return default
+            continue
+        if isinstance(current, dict):
+            if part not in current:
+                return default
+            current = current[part]
+            continue
+        return default
+    return current
+
+
+class APIJsonldSpider(Spider):
+    """
+    Crawl an API that returns paginated JSON with embedded JSON-LD dataset records.
+
+    The spider emits the same `SoscanItem` fields used by the existing pipelines,
+    so normalization and persistence continue to work unchanged.
+    """
+
+    name = "APIJsonldSpider"
+    sitemap_urls = ()
+    api_records_path = "items"
+    api_next_path = "next"
+    api_jsonld_field = None
+    api_url_field = "url"
+    api_modified_field = None
+    api_page_param = None
+    api_start_page = 1
+    api_success_status_codes = (200,)
+    api_stop_status_codes = (204, 404, 410)
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._count_only = kwargs.get("count_only", False)
+        self.lastmod_filter = kwargs.get("lastmod_filter", kwargs.get("lastmod", None))
+        if self.lastmod_filter is not None:
+            self.lastmod_filter = soscan.utils.parseDatetimeString(self.lastmod_filter)
+
+        node_path = kwargs.get("store_path", None)
+        if node_path is not None:
+            node_settings = Path(node_path) / "node.json"
+            if node_settings.exists():
+                with open(node_settings) as src:
+                    node_config = json.loads(src.read())
+                self.sitemap_urls = node_config.get("spider", {}).get("sitemap_urls", self.sitemap_urls)
+
+        urls = kwargs.get("sitemap_urls", None)
+        if urls is None:
+            urls = kwargs.get("api_urls", None)
+        if urls is not None:
+            if isinstance(urls, str):
+                self.sitemap_urls = [u for u in urls.split(" ") if u]
+            else:
+                self.sitemap_urls = list(urls)
+
+        self.api_records_path = kwargs.get("api_records_path", self.api_records_path)
+        self.api_next_path = kwargs.get("api_next_path", self.api_next_path)
+        self.api_jsonld_field = kwargs.get("api_jsonld_field", self.api_jsonld_field)
+        self.api_url_field = kwargs.get("api_url_field", self.api_url_field)
+        self.api_modified_field = kwargs.get("api_modified_field", self.api_modified_field)
+        self.api_page_param = kwargs.get("api_page_param", self.api_page_param)
+        self.api_start_page = int(kwargs.get("api_start_page", self.api_start_page))
+        self.api_success_status_codes = tuple(
+            kwargs.get("api_success_status_codes", self.api_success_status_codes)
+        )
+        self.api_stop_status_codes = tuple(
+            kwargs.get("api_stop_status_codes", self.api_stop_status_codes)
+        )
+
+        if len(self.sitemap_urls) < 1:
+            raise ValueError("At least one sitemap URL is required.")
+
+    @classmethod
+    def from_crawler(cls, crawler, *args, **kwargs):
+        node_path = crawler.settings.get("STORE_PATH", None)
+        kwargs["store_path"] = node_path
+        if node_path is not None:
+            mn_settings = Path(node_path) / "settings.json"
+            if mn_settings.exists():
+                with open(mn_settings) as src:
+                    settings_override = json.loads(src.read())
+                for key in (
+                    "api_records_path",
+                    "api_next_path",
+                    "api_jsonld_field",
+                    "api_url_field",
+                    "api_modified_field",
+                    "api_page_param",
+                    "api_start_page",
+                    "api_success_status_codes",
+                    "api_stop_status_codes",
+                    "lastmod_filter",
+                ):
+                    if key in settings_override:
+                        kwargs[key] = settings_override[key]
+        spider = cls(*args, **kwargs)
+        spider._set_crawler(crawler)
+        return spider
+
+    def start_requests(self):
+        headers = {"Accept": "application/ld+json, application/json;q=0.9, */*;q=0.1"}
+        for url in self.sitemap_urls:
+            req_url = url
+            req_meta = {"api_base_url": url, "api_page": self.api_start_page}
+            if self.api_page_param:
+                req_url = self._set_query_param(url, self.api_page_param, self.api_start_page)
+            yield Request(
+                req_url,
+                callback=self.parse_page,
+                headers=headers,
+                meta={**req_meta, "handle_httpstatus_all": True},
+            )
+
+    def _set_query_param(self, url, key, value):
+        parts = urlsplit(url)
+        params = dict(parse_qsl(parts.query, keep_blank_values=True))
+        params[key] = str(value)
+        query = urlencode(params)
+        return urlunsplit((parts.scheme, parts.netloc, parts.path, query, parts.fragment))
+
+    def _load_payload(self, response):
+        try:
+            return json.loads(response.text)
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"Could not decode API response from {response.url}: {exc}") from exc
+
+    def _normalize_url(self, response, value, default=None):
+        if value in (None, ""):
+            return default
+        return response.urljoin(value)
+
+    def _record_timestamp(self, record):
+        if self.api_modified_field is None:
+            return None
+        return soscan.utils.parseDatetimeString(
+            extract_path(record, self.api_modified_field, None)
+        )
+
+    def _record_to_item(self, response, record, top_context=None):
+        if not isinstance(record, dict):
+            logger.warning("Ignoring non-object record from %s: %r", response.url, record)
+            return None
+
+        time_loc = self._record_timestamp(record)
+        if self.lastmod_filter is not None and time_loc is not None:
+            if time_loc <= self.lastmod_filter:
+                self.logger.debug(
+                    "Skipping API record older than filter: %s <= %s",
+                    time_loc,
+                    self.lastmod_filter,
+                )
+                return None
+
+        record_url = self._normalize_url(
+            response,
+            extract_path(record, self.api_url_field, None),
+            default=response.url,
+        )
+
+        if self._count_only:
+            item = soscan.items.SitemapItem()
+            item["source"] = response.url
+            item["time_retrieved"] = soscan.utils.dtnow()
+            item["url"] = record_url
+            item["time_loc"] = time_loc
+            item["changefreq"] = None
+            item["priority"] = None
+            return item
+
+        jsonld = extract_path(record, self.api_jsonld_field, record)
+        if jsonld is None:
+            logger.warning(
+                "Ignoring API record without JSON-LD at %s using field %s",
+                response.url,
+                self.api_jsonld_field,
+            )
+            return None
+        # Propagate the top-level @context if the record has none of its own.
+        # This is common in ItemList APIs (e.g. schema.org) where @context
+        # is placed once on the envelope rather than on each Dataset.
+        if isinstance(jsonld, dict) and "@context" not in jsonld and top_context is not None:
+            jsonld = {"@context": top_context, **jsonld}
+
+        item = soscan.items.SoscanItem()
+        item["url"] = record_url
+        item["status"] = response.status
+        item["time_loc"] = time_loc
+        item["time_modified"] = None
+        item["time_retrieved"] = soscan.utils.dtnow()
+        item["jsonld"] = jsonld
+        return item
+
+    def _next_request(self, response, payload, record_count):
+        next_url = extract_path(payload, self.api_next_path, None)
+        next_url = self._normalize_url(response, next_url)
+        if next_url not in (None, response.url):
+            headers = {"Accept": "application/ld+json, application/json;q=0.9, */*;q=0.1"}
+            return Request(
+                next_url,
+                callback=self.parse_page,
+                headers=headers,
+                meta={"handle_httpstatus_all": True},
+            )
+
+        if not self.api_page_param:
+            return None
+
+        if response.status in self.api_stop_status_codes:
+            self.logger.info("Stopping API pagination at status %s for %s", response.status, response.url)
+            return None
+
+        if response.status not in self.api_success_status_codes:
+            self.logger.warning(
+                "Stopping API pagination due to non-success status %s at %s",
+                response.status,
+                response.url,
+            )
+            return None
+
+        if record_count < 1:
+            self.logger.info("Stopping API pagination due to empty page at %s", response.url)
+            return None
+
+        current_page = int(response.meta.get("api_page", self.api_start_page))
+        next_page = current_page + 1
+        base_url = response.meta.get("api_base_url", response.url)
+        next_url = self._set_query_param(base_url, self.api_page_param, next_page)
+        headers = {"Accept": "application/ld+json, application/json;q=0.9, */*;q=0.1"}
+        return Request(
+            next_url,
+            callback=self.parse_page,
+            headers=headers,
+            meta={
+                "api_base_url": base_url,
+                "api_page": next_page,
+                "handle_httpstatus_all": True,
+            },
+        )
+
+    def parse_page(self, response):
+        if response.status in self.api_stop_status_codes:
+            self.logger.info(
+                "Received stop status %s at %s; finishing crawl chain.",
+                response.status,
+                response.url,
+            )
+            return
+        if response.status not in self.api_success_status_codes:
+            self.logger.warning(
+                "Ignoring unexpected status %s at %s",
+                response.status,
+                response.url,
+            )
+            return
+
+        payload = self._load_payload(response)
+        records = extract_path(payload, self.api_records_path, [])
+        if isinstance(records, dict):
+            records = [records]
+        elif records is None:
+            records = []
+        elif not isinstance(records, list):
+            raise ValueError(
+                f"API records path {self.api_records_path} did not resolve to a list or object: {type(records)}"
+            )
+
+        # Capture any top-level @context so it can be injected into records
+        # that don't carry their own (e.g. schema.org ItemList APIs).
+        top_context = payload.get("@context", None)
+
+        yielded = 0
+        for record in records:
+            item = self._record_to_item(response, record, top_context=top_context)
+            if item is not None:
+                yielded += 1
+                yield item
+
+        self.logger.info("Processed %s API records from %s", yielded, response.url)
+        next_request = self._next_request(response, payload, yielded)
+        if next_request is not None:
+            yield next_request

--- a/soscan/spiders/apijsonldspider.py
+++ b/soscan/spiders/apijsonldspider.py
@@ -107,6 +107,7 @@ class APIJsonldSpider(Spider):
     def from_crawler(cls, crawler, *args, **kwargs):
         node_path = crawler.settings.get("STORE_PATH", None)
         kwargs["store_path"] = node_path
+        settings_override = {}
         if node_path is not None:
             mn_settings = Path(node_path) / "settings.json"
             if mn_settings.exists():
@@ -128,6 +129,8 @@ class APIJsonldSpider(Spider):
                         kwargs[key] = settings_override[key]
         spider = cls(*args, **kwargs)
         spider._set_crawler(crawler)
+        for key, value in settings_override.items():
+            spider.settings.set(key, value, priority="spider")
         return spider
 
     def start_requests(self):

--- a/soscan/spiders/apijsonldspider.py
+++ b/soscan/spiders/apijsonldspider.py
@@ -297,18 +297,25 @@ class APIJsonldSpider(Spider):
                 f"API records path {self.api_records_path} did not resolve to a list or object: {type(records)}"
             )
 
+        record_count = len(records)
+
         # Capture any top-level @context so it can be injected into records
         # that don't carry their own (e.g. schema.org ItemList APIs).
         top_context = payload.get("@context", None)
 
-        yielded = 0
+        yielded_count = 0
         for record in records:
             item = self._record_to_item(response, record, top_context=top_context)
             if item is not None:
-                yielded += 1
+                yielded_count += 1
                 yield item
 
-        self.logger.info("Processed %s API records from %s", yielded, response.url)
-        next_request = self._next_request(response, payload, yielded)
+        self.logger.info(
+            "Processed %s API records (%s items yielded) from %s",
+            record_count,
+            yielded_count,
+            response.url,
+        )
+        next_request = self._next_request(response, payload, record_count)
         if next_request is not None:
             yield next_request

--- a/tests/test_apijsonldspider.py
+++ b/tests/test_apijsonldspider.py
@@ -147,3 +147,54 @@ def test_page_param_pagination_increments_until_stop_status():
     stop_page = fake_text_response("https://example.org/api/datasets?page=3", status=404)
     stopped = list(spider.parse_page(stop_page))
     assert stopped == []
+
+
+def test_page_param_pagination_continues_when_all_items_filtered_by_lastmod():
+    spider = soscan.spiders.apijsonldspider.APIJsonldSpider(
+        sitemap_urls=["https://example.org/api/datasets"],
+        api_page_param="page",
+        api_next_path="missing_next",
+        api_records_path="items",
+        api_jsonld_field="jsonld",
+        api_modified_field="modified",
+        lastmod_filter="2026-02-01T00:00:00Z",
+    )
+
+    # All items on this page are older than lastmod_filter and should be skipped,
+    # but pagination via page parameter should still continue to the next page.
+    first_page = fake_json_response(
+        "https://example.org/api/datasets?page=1",
+        {
+            "items": [
+                {
+                    "url": "https://example.org/dataset/old-1",
+                    "modified": "2026-01-01T00:00:00Z",
+                    "jsonld": {
+                        "@context": "https://schema.org",
+                        "@type": "Dataset",
+                        "name": "Old Dataset One",
+                    },
+                },
+                {
+                    "url": "https://example.org/dataset/old-2",
+                    "modified": "2026-01-15T00:00:00Z",
+                    "jsonld": {
+                        "@context": "https://schema.org",
+                        "@type": "Dataset",
+                        "name": "Old Dataset Two",
+                    },
+                },
+            ]
+        },
+    )
+    first_page.meta["api_base_url"] = "https://example.org/api/datasets"
+    first_page.meta["api_page"] = 1
+
+    results = list(spider.parse_page(first_page))
+
+    # No items should be yielded because all were filtered out by lastmod_filter,
+    # but a Request for the next page should still be emitted.
+    assert all(not isinstance(r, dict) or "url" not in r or "Old Dataset" not in str(r) for r in results)
+    assert len(results) == 1
+    assert isinstance(results[0], scrapy.http.Request)
+    assert results[0].url == "https://example.org/api/datasets?page=2"

--- a/tests/test_apijsonldspider.py
+++ b/tests/test_apijsonldspider.py
@@ -1,0 +1,149 @@
+import json
+import scrapy.http
+import soscan.spiders.apijsonldspider
+
+
+def fake_json_response(url, payload):
+    request = scrapy.http.Request(url=url)
+    return scrapy.http.TextResponse(
+        url=url,
+        status=200,
+        request=request,
+        body=json.dumps(payload).encode("utf-8"),
+        encoding="utf-8",
+    )
+
+
+def fake_text_response(url, status=200, body=""):
+    request = scrapy.http.Request(url=url)
+    return scrapy.http.TextResponse(
+        url=url,
+        status=status,
+        request=request,
+        body=body.encode("utf-8"),
+        encoding="utf-8",
+    )
+
+
+def test_parse_page_yields_items_and_next_request():
+    spider = soscan.spiders.apijsonldspider.APIJsonldSpider(
+        sitemap_urls=["https://example.org/api/datasets?page=1"],
+        api_records_path="items",
+        api_next_path="next",
+        api_jsonld_field="jsonld",
+        api_url_field="url",
+        api_modified_field="modified",
+    )
+    response = fake_json_response(
+        "https://example.org/api/datasets?page=1",
+        {
+            "items": [
+                {
+                    "url": "https://example.org/dataset/1",
+                    "modified": "2026-02-01T12:00:00Z",
+                    "jsonld": {
+                        "@context": "https://schema.org",
+                        "@type": "Dataset",
+                        "name": "Dataset One",
+                        "identifier": "doi:10.1234/example.1",
+                    },
+                },
+                {
+                    "url": "/dataset/2",
+                    "modified": "2026-02-02T12:00:00Z",
+                    "jsonld": {
+                        "@context": "https://schema.org",
+                        "@type": "Dataset",
+                        "name": "Dataset Two",
+                        "identifier": "doi:10.1234/example.2",
+                    },
+                },
+            ],
+            "next": "?page=2",
+        },
+    )
+
+    results = list(spider.parse_page(response))
+
+    assert len(results) == 3
+    assert results[0]["url"] == "https://example.org/dataset/1"
+    assert results[0]["jsonld"]["@type"] == "Dataset"
+    assert results[1]["url"] == "https://example.org/dataset/2"
+    assert isinstance(results[2], scrapy.http.Request)
+    assert results[2].url == "https://example.org/api/datasets?page=2"
+
+
+def test_parse_page_applies_lastmod_filter_and_count_only():
+    spider = soscan.spiders.apijsonldspider.APIJsonldSpider(
+        sitemap_urls=["https://example.org/api/datasets"],
+        api_records_path="items",
+        api_next_path="next",
+        api_jsonld_field="jsonld",
+        api_url_field="url",
+        api_modified_field="modified",
+        lastmod_filter="2026-02-01T00:00:00Z",
+        count_only=True,
+    )
+    response = fake_json_response(
+        "https://example.org/api/datasets",
+        {
+            "items": [
+                {
+                    "url": "https://example.org/dataset/old",
+                    "modified": "2026-01-01T00:00:00Z",
+                    "jsonld": {"@type": "Dataset", "name": "Old"},
+                },
+                {
+                    "url": "https://example.org/dataset/new",
+                    "modified": "2026-02-03T00:00:00Z",
+                    "jsonld": {"@type": "Dataset", "name": "New"},
+                },
+            ],
+            "next": None,
+        },
+    )
+
+    results = list(spider.parse_page(response))
+
+    assert len(results) == 1
+    assert results[0]["url"] == "https://example.org/dataset/new"
+    assert results[0]["source"] == "https://example.org/api/datasets"
+
+
+def test_page_param_pagination_increments_until_stop_status():
+    spider = soscan.spiders.apijsonldspider.APIJsonldSpider(
+        sitemap_urls=["https://example.org/api/datasets"],
+        api_page_param="page",
+        api_next_path="missing_next",
+        api_records_path="items",
+        api_jsonld_field="jsonld",
+        api_stop_status_codes=[404],
+    )
+
+    first_page = fake_json_response(
+        "https://example.org/api/datasets?page=1",
+        {
+            "items": [
+                {
+                    "url": "https://example.org/dataset/1",
+                    "jsonld": {
+                        "@context": "https://schema.org",
+                        "@type": "Dataset",
+                        "name": "Dataset One",
+                    },
+                }
+            ]
+        },
+    )
+    first_page.meta["api_base_url"] = "https://example.org/api/datasets"
+    first_page.meta["api_page"] = 1
+
+    results = list(spider.parse_page(first_page))
+    assert len(results) == 2
+    assert results[0]["url"] == "https://example.org/dataset/1"
+    assert isinstance(results[1], scrapy.http.Request)
+    assert results[1].url == "https://example.org/api/datasets?page=2"
+
+    stop_page = fake_text_response("https://example.org/api/datasets?page=3", status=404)
+    stopped = list(spider.parse_page(stop_page))
+    assert stopped == []


### PR DESCRIPTION
This PR adds a new spider, `APIJsonldSpider`, which can scrape and return items from a paginated metadata API like the one used by the [Polar Data Catalogue](https://www.polardata.ca/api/metadata).